### PR TITLE
feat: apply a provided version

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,7 +1,9 @@
 name: Test
 
 on:
-  push:
+  pull_request:
+    branches:
+      - master
 
 jobs:
   test:

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![fastlane Plugin Badge](https://rawcdn.githack.com/fastlane/fastlane/master/fastlane/assets/plugin-badge.svg)](https://rubygems.org/gems/fastlane-plugin-flutter_bump_version)
 [![Plugin Version](https://badge.fury.io/rb/fastlane-plugin-flutter_bump_version.svg)](https://badge.fury.io/rb/fastlane-plugin-flutter_bump_version)
 [![Test](https://github.com/M97Chahboun/fastlane-plugin-flutter_bump_version/actions/workflows/test.yml/badge.svg)](https://github.com/M97Chahboun/fastlane-plugin-flutter_bump_version/actions/workflows/test.yml)
+
 ## Getting Started
 
 This project is a [_fastlane_](https://github.com/fastlane/fastlane) plugin. To get started with `fastlane-plugin-flutter_bump_version`, add it to your project by running:
@@ -21,19 +22,23 @@ Check out the [example `Fastfile`](fastlane/Fastfile) to see how to use this plu
 
 You can `bump` multi parts of version you want by use instead of `patch` (`major`,`minor` or `patch`) split it by (,)
 
-As Example :
+Example :
 
-old version : 1.0.0
+old version : `1.0.0`
 
 ```sh
 [bundle exec] fastlane bump_version bump:major,minor,minor,patch
 ```
-new version : 2.2.1
 
-build (version code) auto-increase based on current version code & you can disable it by pass `false` with bump_build parameter
-if you not pass any option or wrong option with command will bump build as default
+new version : `2.2.1`
 
-And the `push` if `true` plugin will bump version & create tag from it then push to git remote if `false` not do anything
+## Available options
+
+- `bump_build`: build (version code) auto-increases based on current version code. You can disable it by passing `false` to this parameter. If you don't pass any options, the command will bump the `build` by default.
+- `push`: You can automatically create a tag and push it to git remote if you pass the `push: true` parameter.
+- `version`: provide a version using the SemVer format (`x.x.x`) to be applied to the `pubspec.yaml` file. The build part is managed by the `bump_build` parameter.
+
+See [available options](./lib/fastlane/plugin/flutter_bump_version/actions/flutter_bump_version_action.rb#L159) in the source file for more on available options.
 
 ## Issues and Feedback
 
@@ -50,4 +55,3 @@ For more information about how the `fastlane` plugin system works, check out the
 ## About _fastlane_
 
 _fastlane_ is the easiest way to automate beta deployments and releases for your iOS and Android apps. To learn more, check out [fastlane.tools](https://fastlane.tools).
-

--- a/lib/fastlane/plugin/flutter_bump_version/actions/flutter_bump_version_action.rb
+++ b/lib/fastlane/plugin/flutter_bump_version/actions/flutter_bump_version_action.rb
@@ -175,7 +175,7 @@ module Fastlane
           ),
           FastlaneCore::ConfigItem.new(
             key: :version,
-            description: "Provide a new version to update and automatically update build number",
+            description: "Provide a new version to apply and automatically update build number",
             optional: true,
             type: String
           )

--- a/lib/fastlane/plugin/flutter_bump_version/version.rb
+++ b/lib/fastlane/plugin/flutter_bump_version/version.rb
@@ -1,5 +1,5 @@
 module Fastlane
   module FlutterBumpVersion
-    VERSION = "0.3.2"
+    VERSION = "0.3.0"
   end
 end

--- a/lib/fastlane/plugin/flutter_bump_version/version.rb
+++ b/lib/fastlane/plugin/flutter_bump_version/version.rb
@@ -1,5 +1,5 @@
 module Fastlane
   module FlutterBumpVersion
-    VERSION = "0.2.2"
+    VERSION = "0.3.2"
   end
 end

--- a/spec/flutter_bump_version_action_spec.rb
+++ b/spec/flutter_bump_version_action_spec.rb
@@ -40,5 +40,20 @@ describe Fastlane::Actions::FlutterBumpVersionAction do
       expect(Fastlane::UI).to receive(:message).with("New app version: 4.1.0+6")
       Fastlane::Actions::FlutterBumpVersionAction.run(pubspec: "./pubspec.yaml", bump_build: false)
     end
+    it 'Bump provided version & Show Previous & New Version' do
+      expect(Fastlane::UI).to receive(:message).with("Previous app version: 4.1.0+6")
+      expect(Fastlane::UI).to receive(:message).with("New app version: 5.3.1+7")
+      Fastlane::Actions::FlutterBumpVersionAction.run(pubspec: "./pubspec.yaml", version: "5.3.1")
+    end
+    it 'Bump provided version with bump_build:false' do
+      expect(Fastlane::UI).to receive(:message).with("Previous app version: 5.3.1+7")
+      expect(Fastlane::UI).to receive(:message).with("New app version: 6.1.2+7")
+      Fastlane::Actions::FlutterBumpVersionAction.run(pubspec: "./pubspec.yaml", version: "6.1.2", bump_build: false)
+    end
+    it 'Errors if wrong version format provided' do
+      expect do
+        Fastlane::Actions::FlutterBumpVersionAction.run(pubspec: "./pubspec.yaml", version: "1.0")
+      end.to raise_error(StandardError, "Invalid version format. Please provide version in format x.x.x")
+    end
   end
 end


### PR DESCRIPTION
introduce a new feature to allow users to provide their version in a string format (major.minor.patch) and automatically increment the build number accordingly. 
This allows for better integration w/ other tools that can automatically determine the version number

For example, it can be integrated with semantic release tools that can determine the next version number.
Then, in the CI pipeline, the version number will be used with this Fastlane plugin to update the Flutter's project `pubspec.yaml`.

Hope you'll consider it !